### PR TITLE
enable Enter key to search feature request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/feature_requests
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/Components/SearchBar/SearchBar.js
+++ b/src/Components/SearchBar/SearchBar.js
@@ -11,7 +11,15 @@ export default class SearchBar extends Component {
 
     this.handleTermChange = this.handleTermChange.bind(this);
 
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+
     this.search = this.search.bind(this);
+  }
+
+  handleKeyDown(event) {
+    if (event.key === 'Enter') {
+      this.search();
+    }
   }
 
   handleTermChange(event) {
@@ -27,7 +35,7 @@ export default class SearchBar extends Component {
   render() {
     return (
       <div className="SearchBar">
-        <input placeholder="Enter A Song, Album, or Artist" onChange={this.handleTermChange} />
+        <input placeholder="Enter A Song, Album, or Artist" onChange={this.handleTermChange} onKeyDown={this.handleKeyDown} />
         <a onClick={this.search} >SEARCH</a>
       </div>
     )

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -1,5 +1,4 @@
-const clientId = 'REMOVED TO PUBlISH TO GITHUB';
-const redirectUri = 'https://dwpdxjamming.surge.sh/';
+const clientId = 'REMOVED FOR GITHUB';
 
 let userAccessToken;
 let expiresIn;
@@ -23,9 +22,19 @@ const Spotify = {
         window.history.pushState('Access Token', null, '/');
         return userAccessToken;
       } else {
-        let targetUrl = `https://accounts.spotify.com/authorize?client_id=${clientId}&response_type=token&scope=playlist-modify-public&redirect_uri=${redirectUri}`;
+        let targetUrl = `https://accounts.spotify.com/authorize?client_id=${clientId}&response_type=token&scope=playlist-modify-public&redirect_uri=${this.getRedirectUri()}`;
         window.location.href = targetUrl;
       }
+    }
+  },
+
+  getRedirectUri() {
+    if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+      console.log('Development');
+      return 'http://localhost:3000/';
+    } else {
+      console.log('Production');
+      return 'https://dwpdxjamming.surge.sh/';
     }
   },
 


### PR DESCRIPTION
Currently Jamming allows a user to search the Spotify API for songs, albums, or artists by inputting their search term in the SearchBar, and then clicking the SEARCH link.

A common feature in online forms is the ability to press the ENTER key on a keyboard to trigger/submit the form.

Supporting this feature could enhance the user experience by allowing an alternative action to trigger their search.

This feature accomplishes the following:

- Allow a user to submit the search form by pressing ENTER while inside the search term input field.
- Also maintain the ability to click the SEARCH link to trigger a search.
